### PR TITLE
Update .prettierrc.js

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -5,4 +5,6 @@ module.exports = {
   printWidth: 80,
   singleQuote: true,
   arrowParens: 'always',
+  trailingComma: 'all',
+  endOfLine: 'lf',
 };


### PR DESCRIPTION
# Description

This should ensure that PC users don't get prettier errors because of wrong line endings.

# How to test?

On PC: Clone the repository again (unfortunately line endings get set on checkout so you need to finish your existing work, push it to github and delete and clone the local repo again). Perform code changes that involve line endings. Make sure prettier is formatting your code in your editor. Run `npm run code:check` to verify that Prettier checks passes.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have merged the latest version of the source branch (typically develop) into this branch before pushing my changes
- [x] This PR is ready to be merged and not breaking any other functionality
