### PR TITLE
Added missing defaultTo(knex.fn.now()) and fk_game_user_id

### DIFF
--- a/src/server/migrations/20200602211147_themes.js
+++ b/src/server/migrations/20200602211147_themes.js
@@ -2,8 +2,8 @@ exports.up = function (knex) {
   return knex.schema.createTable('themes', (table) => {
     table.increments('id');
     table.string('tile');
-    table.timestamp('created_at').notNullable();
-    table.timestamp('updated_at').notNullable();
+    table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
+    table.timestamp('updated_at').defaultTo(knex.fn.now()).notNullable();
     table.timestamp('deleted_at');
   });
 };

--- a/src/server/migrations/20200602212442_maps.js
+++ b/src/server/migrations/20200602212442_maps.js
@@ -9,8 +9,8 @@ exports.up = function (knex) {
     table.float('long_bottom_left');
     table.float('lat_bottom_right');
     table.float('long_bottom_right');
-    table.timestamp('created_at').notNullable();
-    table.timestamp('updated_at').notNullable();
+    table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
+    table.timestamp('updated_at').defaultTo(knex.fn.now()).notNullable();
     table.timestamp('deleted_at');
   });
 };

--- a/src/server/migrations/20200602213728_game_factory.js
+++ b/src/server/migrations/20200602213728_game_factory.js
@@ -6,7 +6,7 @@ exports.up = function (knex) {
     table.integer('fk_theme_id').unsigned();
     table.foreign('fk_theme_id').references('id').inTable('themes');
     table.integer('max_players');
-    table.timestamp('created_at').notNullable();
+    table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
     table.timestamp('updated_at').notNullable();
     table.timestamp('deleted_at');
   });

--- a/src/server/migrations/20200602213728_game_factory.js
+++ b/src/server/migrations/20200602213728_game_factory.js
@@ -5,9 +5,11 @@ exports.up = function (knex) {
     table.foreign('fk_map_id').references('id').inTable('maps');
     table.integer('fk_theme_id').unsigned();
     table.foreign('fk_theme_id').references('id').inTable('themes');
+    table.integer('fk_game_user_id').unsigned();
+    table.foreign('fk_game_user_id').references('id').inTable('users');
     table.integer('max_players');
     table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
-    table.timestamp('updated_at').notNullable();
+    table.timestamp('updated_at').defaultTo(knex.fn.now()).notNullable();
     table.timestamp('deleted_at');
   });
 };

--- a/src/server/migrations/20200602214116_questions.js
+++ b/src/server/migrations/20200602214116_questions.js
@@ -7,8 +7,8 @@ exports.up = function (knex) {
     table.float('latitude').notNullable();
     table.float('longitude').notNullable();
     table.integer('points');
-    table.timestamp('created_at').notNullable();
-    table.timestamp('updated_at').notNullable();
+    table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
+    table.timestamp('updated_at').defaultTo(knex.fn.now()).notNullable();
     table.timestamp('deleted_at');
   });
 };

--- a/src/server/migrations/20200602225007_answer_choices.js
+++ b/src/server/migrations/20200602225007_answer_choices.js
@@ -5,8 +5,8 @@ exports.up = function (knex) {
     table.integer('fk_question_id').unsigned();
     table.foreign('fk_question_id').references('id').inTable('questions');
     table.boolean('answer_correct');
-    table.timestamp('created_at').notNullable();
-    table.timestamp('updated_at').notNullable();
+    table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
+    table.timestamp('updated_at').defaultTo(knex.fn.now()).notNullable();
     table.timestamp('deleted_at');
   });
 };


### PR DESCRIPTION
# Description
Added missing defaultTo(knex.fn.now()) in the fields created_at and updated_at from themes, maps, game_factory, questions and answer_choices. 
Added fk_game_user_id. 

Associated to #43 

# How to test?
npm run db:setup

# Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have merged the latest version of the source branch (typically develop) into this branch before pushing my changes
- [X] This PR is ready to be merged and not breaking any other functionality
