### PR TITLE
Correcting columns name in DB

### DIFF
--- a/src/server/migrations/20200622165517_rename_cols_game_instances.js
+++ b/src/server/migrations/20200622165517_rename_cols_game_instances.js
@@ -7,7 +7,7 @@ exports.up = function (knex) {
 
 exports.down = function (knex) {
   return knex.schema.table('game_instances', function (table) {
-    table.renameColumn('Finished', 'finished');
-    table.renameColumn('fk_game_id', 'fk_game_factory_id');
+    table.renameColumn('finished', 'Finished');
+    table.renameColumn('fk_game_factory_id', 'fk_game_id');
   });
 };

--- a/src/server/migrations/20200622165517_rename_cols_game_instances.js
+++ b/src/server/migrations/20200622165517_rename_cols_game_instances.js
@@ -1,0 +1,13 @@
+exports.up = function (knex) {
+  return knex.schema.table('game_instances', function (table) {
+    table.renameColumn('Finished', 'finished');
+    table.renameColumn('fk_game_id', 'fk_game_factory_id');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table('game_instances', function (table) {
+    table.renameColumn('Finished', 'finished');
+    table.renameColumn('fk_game_id', 'fk_game_factory_id');
+  });
+};

--- a/src/server/migrations/20200622165958_rename_col_questions.js
+++ b/src/server/migrations/20200622165958_rename_col_questions.js
@@ -6,6 +6,6 @@ exports.up = function (knex) {
 
 exports.down = function (knex) {
   return knex.schema.table('questions', function (table) {
-    table.renameColumn('fk_game_id', 'fk_game_factory_id');
+    table.renameColumn('fk_game_factory_id', 'fk_game_id');
   });
 };

--- a/src/server/migrations/20200622165958_rename_col_questions.js
+++ b/src/server/migrations/20200622165958_rename_col_questions.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.table('questions', function (table) {
+    table.renameColumn('fk_game_id', 'fk_game_factory_id');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table('questions', function (table) {
+    table.renameColumn('fk_game_id', 'fk_game_factory_id');
+  });
+};

--- a/src/server/seeds/development/08_questions.js
+++ b/src/server/seeds/development/08_questions.js
@@ -5,14 +5,14 @@ exports.seed = function (knex) {
       return knex('questions').insert([
         {
           question: 'Which of these famous Danes was not born in Copenhagen?',
-          fk_game_id: 1,
+          fk_game_factory_id: 1,
           latitude: '55.6763131',
           longitude: '12.5671846',
           points: 10,
         },
         {
           question: 'Which of these letters is not in the Danish alphabet? ',
-          fk_game_id: 1,
+          fk_game_factory_id: 1,
           longitude: '55.6776705',
           latitude: '12.5758562',
           points: 10,
@@ -20,21 +20,21 @@ exports.seed = function (knex) {
         {
           question:
             'What percentage of people living in Copenhagen are foreigners?',
-          fk_game_id: 1,
+          fk_game_factory_id: 1,
           longitude: '55.6746509',
           latitude: '12.5725523',
           points: 10,
         },
         {
           question: 'Which one of the following cities is not a Danish city?',
-          fk_game_id: 1,
+          fk_game_factory_id: 1,
           longitude: '55.6781781',
           latitude: '12.5760579',
           points: 10,
         },
         {
           question: 'What is the Swedish spelling of Copenhagen?',
-          fk_game_id: 1,
+          fk_game_factory_id: 1,
           longitude: '55.6797691',
           latitude: '12.5897041',
           points: 10,
@@ -42,7 +42,7 @@ exports.seed = function (knex) {
         {
           question:
             "Which of these is not the name of a neighborhood in Copenhagen?'",
-          fk_game_id: 1,
+          fk_game_factory_id: 1,
           longitude: '55.6762346',
           latitude: '12.5783256',
           points: 10,
@@ -50,7 +50,7 @@ exports.seed = function (knex) {
         {
           question:
             "Which country's navy bombarded Copenhagen from the sea in 1807?",
-          fk_game_id: 1,
+          fk_game_factory_id: 1,
           longitude: '55.6750213',
           latitude: '12.5681225',
           points: 10,
@@ -58,7 +58,7 @@ exports.seed = function (knex) {
         {
           question:
             "What is the name of the annual summer street festival that reverberates through Copenhagen's streets?",
-          fk_game_id: 1,
+          fk_game_factory_id: 1,
           longitude: '55.6888157',
           latitude: '12.5761416',
           points: 10,
@@ -66,21 +66,21 @@ exports.seed = function (knex) {
         {
           question:
             'How high is the Round Tower or in Danish Rundetaarn in Copenhagen?',
-          fk_game_id: 1,
+          fk_game_factory_id: 1,
           longitude: '55.68135',
           latitude: '12.5735412',
           points: 10,
         },
         {
           question: "What's the name of the oldest amusement park in Denmark?",
-          fk_game_id: 1,
+          fk_game_factory_id: 1,
           longitude: '55.6736871',
           latitude: '12.5659584',
           points: 10,
         },
         {
           question: 'Where does the royal family live in Copenhagen?',
-          fk_game_id: 1,
+          fk_game_factory_id: 1,
           longitude: '55.6852935',
           latitude: '12.5776565',
           points: 10,
@@ -88,14 +88,14 @@ exports.seed = function (knex) {
         {
           question:
             'What is the name of the fairy tale from HC Andersen where the main character is a woman that is half fish?',
-          fk_game_id: 1,
+          fk_game_factory_id: 1,
           longitude: '55.6787501',
           latitude: '12.5715252',
           points: 10,
         },
         {
           question: 'Which ones of the following inventions are danish?',
-          fk_game_id: 1,
+          fk_game_factory_id: 1,
           longitude: '55.6808644',
           latitude: '12.5823393',
           points: 10,


### PR DESCRIPTION
# Description
Change the name of this columns in the tables and in the seeds: 
 **game_instances**: fk_game_id > fk_game_factory_id 
                                  Finished >finished
**questions** fk_game_id > fk_game_factory_id 


# How to test?
 `npm run db:setup` or `knex migrate:latest`

# Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have merged the latest version of the source branch (typically develop) into this branch before pushing my changes
- [X] This PR is ready to be merged and not breaking any other functionality
